### PR TITLE
IBP-4789 IBP-5138

### DIFF
--- a/nginx/bms.conf
+++ b/nginx/bms.conf
@@ -4,3 +4,12 @@ proxy_cookie_path /Fieldbook "/Fieldbook; HTTPOnly; Secure; SameSite=strict";
 proxy_cookie_path /GDMS "/GDMS; HTTPOnly; Secure; SameSite=strict";
 proxy_cookie_path /inventory-manager "/inventory-manager; HTTPOnly; Secure; SameSite=strict";
 proxy_cookie_path /bmsapi "/bmsapi; HTTPOnly; Secure;";
+
+# Close connections that are writing data too infrequently, which can represent an attempt to keep
+# connections open as long as possible (thus reducing the server’s ability to accept new connections)
+# Wait no more than 10 seconds between writes from the client for either headers or body:
+client_body_timeout 10s;
+client_header_timeout 10s;
+
+# Set zone name for connection limit per ip address
+limit_conn_zone $binary_remote_addr zone=limit_connection_per_ip_addr:10m;

--- a/nginx/default_location
+++ b/nginx/default_location
@@ -2,3 +2,7 @@ proxy_connect_timeout       600;
 proxy_send_timeout          600;
 proxy_read_timeout          600;
 send_timeout                600;
+
+# Limit concurrent connection per ip address
+# See bms.conf for the zone name
+limit_conn limit_connection_per_ip_addr 100;


### PR DESCRIPTION
Mitigate Slow Http Post vulnerability by decreasing the client_body_timeout (inactivity timeout while reading a client request body) and client_header_timeout (inactivity timeout while reading a client request header) to 15 seconds. Also applied limit to number of concurrent connections a client can have at a time.

IBP-4789