### PR TITLE
IBP-5398 IBP-5478: Add BASE_URL to docker compose (brapi-sync integration)

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,12 @@ BMS_MEMORY=2g
 # To enable, set to -Dspring.profiles.active=development
 LIQUIBASE_PARAM=-Dspring.profiles.active=development
 
+# Public absolute url
+# Used for OAuth (e.g KSU Fieldbook, brapi-sync)
+# if BMS runs behind a proxy this info cannot be known by the system except for this property
+# e.g BASE_URL=https://bms-centos-1.leafnode.io
+#BASE_URL=
+
 # Variables when running BMS with SSL
 #BMS_SSL_HOST=bmsdock.leafnode.io
 #BMS_SSL_EMAIL=leafnodedev@leafnode.io

--- a/docker-compose-custom-ssl.yml
+++ b/docker-compose-custom-ssl.yml
@@ -37,6 +37,7 @@ services:
       - BMS_DB_PASSWORD=${BMS_DB_PASS:?err}
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
+      - BASE_URL=${BASE_URL:-}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./logs:/usr/local/tomcat/logs

--- a/docker-compose-ssl.yml
+++ b/docker-compose-ssl.yml
@@ -64,6 +64,7 @@ services:
       - BMS_DB_PASSWORD=${BMS_DB_PASS:?err}
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
+      - BASE_URL=${BASE_URL:-}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./custom:/custom

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
       - BMS_DB_PASSWORD=${BMS_DB_PASS:?err}
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
+      - BASE_URL=${BASE_URL:-}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./custom:/custom

--- a/multi-docker-compose-app.yml
+++ b/multi-docker-compose-app.yml
@@ -27,6 +27,7 @@ services:
       - BMS_DB_PASSWORD=${BMS_DB_PASS:?err}
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
+      - BASE_URL=${BASE_URL:-}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./logs:/usr/local/tomcat/logs


### PR DESCRIPTION
BASE_URL was used until recently only for OAuth Brapi flow.
Now it's also used for brapi-sync integration into BMS, which means it's  more important to keep the property between deploys.
The [property in BMSAPI](https://github.com/IntegratedBreedingPlatform/BMSAPI/blob/a19b511eb77c856b3f2b428d80e72adf611c41f4/src/main/resources/application.properties#L6) is already prepared to resolve from environment variable, but it was not added in the docker compose file.

After this we can update/set the .env file in the **centos** servers so that brapi-sync can be run always at least between these servers (plus also we automatically enable KSU Fieldbook OAuth Flow). Otherwise the property in bmsapi must be always changed every time we want to test it.
I left it as empty by default (`${BASE_URL:-}`) instead of error because the system will work even if not set in the `.env` file, but we can start thinking in making it mandatory in the future.
**I haven't tested it** , @abatac @darla-leafnode  please review and apply it if you agree .


cc @IntegratedBreedingPlatform/developers 
