### PR TITLE
IBP-5874: Disable security.2fa.enforce.otp.on.unknown.device by default

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -8,6 +8,14 @@ BMS_MEMORY=2g
 # To enable, set to -Dspring.profiles.active=development
 LIQUIBASE_PARAM=-Dspring.profiles.active=development
 
+#################################
+# 2FA (two factor authentication)
+#################################
+# enable/disable globally
+#SECURITY_2FA_ENABLED=false
+# Enforce two factor authentication when user logs in to an unknown device
+#SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE=true
+
 # Public absolute url
 # Used for OAuth (e.g KSU Fieldbook, brapi-sync)
 # if BMS runs behind a proxy this info cannot be known by the system except for this property

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/.idea/
+/.env
+/start.log

--- a/docker-compose-custom-ssl.yml
+++ b/docker-compose-custom-ssl.yml
@@ -38,6 +38,8 @@ services:
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
       - BASE_URL=${BASE_URL:-}
+      - SECURITY_2FA_ENABLED=${SECURITY_2FA_ENABLED:-true}
+      - SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE=${SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE:-false}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./logs:/usr/local/tomcat/logs

--- a/docker-compose-ssl.yml
+++ b/docker-compose-ssl.yml
@@ -65,6 +65,8 @@ services:
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
       - BASE_URL=${BASE_URL:-}
+      - SECURITY_2FA_ENABLED=${SECURITY_2FA_ENABLED:-true}
+      - SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE=${SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE:-false}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./config:/bms/BMSConfig/bmsdocker

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
       - BASE_URL=${BASE_URL:-}
+      - SECURITY_2FA_ENABLED=${SECURITY_2FA_ENABLED:-true}
+      - SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE=${SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE:-false}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./config:/bms/BMSConfig/bmsdocker

--- a/multi-docker-compose-app.yml
+++ b/multi-docker-compose-app.yml
@@ -28,6 +28,8 @@ services:
       - CATALINA_OPTS=-javaagent:/opt/spring-instrument-4.1.6.RELEASE.jar
       - JAVA_OPTS=-server -Xms${BMS_MEMORY:?err} -Xmx${BMS_MEMORY:?err} -XX:+CMSClassUnloadingEnabled ${LIQUIBASE_PARAM}
       - BASE_URL=${BASE_URL:-}
+      - SECURITY_2FA_ENABLED=${SECURITY_2FA_ENABLED:-true}
+      - SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE=${SECURITY_2FA_ENFORCE_OTP_ON_UNKNOWN_DEVICE:-false}
     volumes:
       - mysqldata:/var/lib/mysql
       - ./logs:/usr/local/tomcat/logs


### PR DESCRIPTION
To be able to log in by default using different devices without having
to  provide one-time-password, like when using a default admin account
in  testing environments.

This stricter property can be enabled on demand by overriding it with environment variables.